### PR TITLE
pusher order channel and subscription

### DIFF
--- a/src/components/gorhom/bottom-sheets/orderDetailsViewSheet.tsx
+++ b/src/components/gorhom/bottom-sheets/orderDetailsViewSheet.tsx
@@ -36,6 +36,7 @@ import {observer} from 'mobx-react-lite';
 import {SheetManager} from 'react-native-actions-sheet';
 import {launchImageLibrary} from 'react-native-image-picker';
 import Toast from 'react-native-toast-message';
+import {UsePusher} from '@hooks/usePusher.ts';
 
 export const OrderDetailsViewSheet = observer(() => {
   const sheetRef: any = useRef<BottomSheet>(null);
@@ -65,6 +66,8 @@ export const OrderDetailsViewSheet = observer(() => {
   const request_id = payload?.request_id ?? ordersData?.misc_rider_info?.id;
 
   const {isBackground, isForeground, currentAppState} = useAppState();
+
+  const {unsuscribe, subscribe} = UsePusher();
 
   // variables
   const snapPoints = useMemo(() => ['30%', '60%', '85%'], []);
@@ -150,6 +153,7 @@ export const OrderDetailsViewSheet = observer(() => {
               per_page: 6,
               status: '1',
             });
+            unsuscribe(`private.orders.ready.${order_id}`);
             setUploadedOrder([]);
             const pay: any = {
               customer_id: ordersData.customer_id,

--- a/src/hooks/usePusher.ts
+++ b/src/hooks/usePusher.ts
@@ -7,10 +7,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {authStore} from '@store/auth';
 import {useCallback, useEffect} from 'react';
 import {STORAGE_KEY} from '../constant';
+import async from '../config/async.ts';
 
 interface PusherHookReturn {
   subscribe: (channelName: string, callback: (data: any) => void) => void;
   pusherEvent: any;
+  unsuscribe: (channelName: string) => void;
   //   bind: (eventName: string, callback: (data: any) => void) => void;
   //   unsubscribe: (channelName: string) => void;
   //   trigger: (channelName: string, eventName: string, data: any) => void;
@@ -33,31 +35,31 @@ export const UsePusher = (): PusherHookReturn => {
         authorizerTimeoutInSeconds: 30, //30sec
         apiKey: PusherInstance.appKey ?? '',
         cluster: PusherInstance.cluster ?? '',
-        // onAuthorizer: async (channelName: string, socketId: string) => {
-        //   console.log('calling authorizer', {channelName, socketId});
-        //   try {
-        //     const token = await AsyncStorage.getItem(STORAGE_KEY.ACCESS_TOKEN);
-        //     const response = await fetch(
-        //       'https://9ff5-102-219-152-26.ngrok-free.app/api/broadcasting/auth',
-        //       {
-        //         method: 'POST',
-        //         headers: {
-        //           'Content-Type': 'application/json',
-        //           Authorization: 'Bearer ' + token,
-        //         },
-        //         body: JSON.stringify({
-        //           socket_id: socketId,
-        //           channel_name: channelName,
-        //         }),
-        //       },
-        //     );
-        //     const body = (await response.json()) as PusherAuthorizerResult;
-        //     console.log(JSON.stringify(body, null, 2), ' NEW PUSHER');
-        //     return body;
-        //   } catch (error) {
-        //     console.log(error);
-        //   }
-        // },
+        onAuthorizer: async (channelName: string, socketId: string) => {
+          console.log('calling authorizer', {channelName, socketId});
+          try {
+            const token = await AsyncStorage.getItem(STORAGE_KEY.ACCESS_TOKEN);
+            const response = await fetch(
+              'https://9ff5-102-219-152-26.ngrok-free.app/api/broadcasting/auth',
+              {
+                method: 'POST',
+                headers: {
+                   'Content-Type': 'application/json',
+                   Authorization: 'Bearer ' + token,
+                 },
+                 body: JSON.stringify({
+                   socket_id: socketId,
+                   channel_name: channelName,
+                 }),
+               },
+             );
+             const body = (await response.json()) as PusherAuthorizerResult;
+             console.log(JSON.stringify(body, null, 2), ' NEW PUSHER');
+             return body;
+           } catch (error) {
+             console.log(error);
+           }
+           },
       });
       await pusher.connect();
     };
@@ -69,6 +71,8 @@ export const UsePusher = (): PusherHookReturn => {
     async (channelName: string, callback: (data: any) => void) => {
       if (pusher) {
         console.log('THERE IS PUSHER');
+        const Id = userD?.user?.id?.toString();
+        channelName = channelName.replace('userId', Id);
         await pusher.subscribe({
           channelName: channelName,
           onSubscriptionSucceeded: data => {
@@ -84,6 +88,7 @@ export const UsePusher = (): PusherHookReturn => {
           onEvent: (event: PusherEvent) => {
             // console.log(`Event received: ${event}`);
             callback(event);
+
           },
           onSubscriptionError(channelName, message, e) {
             console.log(`Subscription error: ${channelName}, ${message}`);
@@ -94,8 +99,24 @@ export const UsePusher = (): PusherHookReturn => {
     [],
   );
 
+  const unsuscribe = useCallback(async (channelName: string) => {
+
+    const Id = userD?.user?.id?.toString();
+    channelName = channelName.replace('userId', Id);
+    pusher.trigger({
+      eventName: '',
+      channelName: '',
+      data: {},
+      userId: id,
+    })
+    await pusher.unsubscribe({
+      channelName,
+    });
+  }, [])
+
   return {
     subscribe,
+    unsuscribe,
     pusherEvent,
   };
 };

--- a/src/screens/app/Home/components/orderRequest.tsx
+++ b/src/screens/app/Home/components/orderRequest.tsx
@@ -16,6 +16,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import Toast from 'react-native-toast-message';
 import {WIN_HEIGHT} from '../../../../config';
+import {UsePusher} from '@hooks/usePusher.ts';
 
 export const OrderRequest = observer(() => {
   const NotificationOrder: any = ordersStore.notifiedOrder;
@@ -30,6 +31,7 @@ export const OrderRequest = observer(() => {
   const boxHeight = useSharedValue(WIN_HEIGHT * boxChangeableHeight);
 
   const {acceptOrder, reassignOrder} = useOrders();
+  const {unsuscribe, subscribe} = UsePusher();
 
   const allOrders = ordersStore.orders;
 
@@ -96,6 +98,22 @@ export const OrderRequest = observer(() => {
               setMainNotificationOrder({});
               ordersStore.setSelectedOrderId(Number(order_id));
               bottomSheetStore.SetSheet('orderDetailsView', true);
+              unsuscribe('private.orders.approved.userId')
+              subscribe(`private.orders.ready.userId.${order_id}`, (data: any) => {
+                //waiting for when seller mark order this order to be ready
+                //events - ready, arrival, pick up, delivered
+                console.log('data', data);
+                if (data.eventName === 'rider_order_pickup') {
+                  Toast.show({
+                    type: 'success',
+                    text1: 'Order Ready for Pickup',
+                    text2: 'Your order is ready for pickup',
+                    swipeable: true,
+                    visibilityTime: 6000,
+                  });
+                }
+
+              })
             } else {
               Toast.show({
                 type: 'warning',

--- a/src/screens/app/Home/index.tsx
+++ b/src/screens/app/Home/index.tsx
@@ -455,47 +455,47 @@ export const Home = observer((props: HomeProps) => {
   }, [selectedOrder]);
 
   // pusher event setup
+
+  useEffect(() => {
+    subscribe('private-users.compliance.userId', (data: PusherEvent) => {
+      // another channel private room should be created to handle compliance message,
+      // it should strictly private and not public
+      // also we can't hold subscription forever it's expensive and not scalable,
+      //put a mechanism to check when compliance is completed and done, then unsuscribe from the channel after compliance is done
+      if (data.eventName === 'user_compliance_approve') {
+        userDetails.refetch();
+        Toast.show({
+          type: 'success',
+          text1: 'Compliance Approval',
+          text2:
+            'Your compliance has been approved you can now go online to receive orders.',
+          swipeable: true,
+          visibilityTime: 6000,
+        });
+      }
+      if (data.eventName === 'user_compliance_reject') {
+        userDetails.refetch();
+        Toast.show({
+          type: 'error',
+          text1: 'Compliance Approval',
+          text2: 'Your compliance has been rejected',
+          swipeable: true,
+          visibilityTime: 6000,
+        });
+      }
+  }, [subscribe, userDetails]);
   useEffect(() => {
     subscribe(
-      `private-orders.approved.${userD?.user?.id}`,
+      `private-orders.approved.userId`,
       (data: PusherEvent) => {
-        if (data.eventName === 'user_compliance_approve') {
-          userDetails.refetch();
-          Toast.show({
-            type: 'success',
-            text1: 'Compliance Approval',
-            text2:
-              'Your compliance has been approved you can now go online to receive orders.',
-            swipeable: true,
-            visibilityTime: 6000,
-          });
-        }
-        if (data.eventName === 'user_compliance_reject') {
-          userDetails.refetch();
-          Toast.show({
-            type: 'error',
-            text1: 'Compliance Approval',
-            text2: 'Your compliance has been rejected',
-            swipeable: true,
-            visibilityTime: 6000,
-          });
-        }
         if (data.eventName === 'rider_new_order') {
           console.log('NEW ORDER CAME IN!', JSON.stringify(data, null, 2));
           const dData = data.data;
           const parsed = JSON.parse(dData);
           ordersStore.setNotifiedOrder(parsed);
         }
+        //move this to private-ready channel
         if (data.eventName === 'rider_cancel_order') {
-        }
-        if (data.eventName === 'rider_order_pickup') {
-          Toast.show({
-            type: 'success',
-            text1: 'Order Ready for Pickup',
-            text2: 'Your order is ready for pickup',
-            swipeable: true,
-            visibilityTime: 6000,
-          });
         }
       },
     );


### PR DESCRIPTION
# This is not really for merge!

I checked the pusher event and subscription implementation, we're currently not handling it well.
### we can't keep socket open forever,it too expensive and not scalable, we've limited connections ([Pusher plans](https://dashboard.pusher.com/plans))

0. Currently, all users are subscribed to the `FastFast` channel, which is a public channel. All users will receive the same messages, regardless of whether they are intended for them or not.
1. I added unsubscribe hook to remove subscription once the user is  done with a particular activity
 2. for user compliance and verification, I've created a channel for that but should only be use for user whose compliance are not done yet (we'll need to add a logic to check that only riders whose compliance are not done should subscribe) else unsubscribe the user from it. Once their compliance is verified, unsubscribe them from it.
 2. Added another order channel to manage rider orders throughout the order delivery process. Once an order is completed, the rider will be unsubscribed and moved back to go online.
 
 ## Channel Order subscription
1. When riders go online, subscribe them to `presence-orders.approved.{userId}`, which listen to order approved event. All riders in a particular location will be in this same channel(room) and get the order approved message.
2. The rider who successfully accepts this order will be removed from the `presence-orders.approved.{userId}` channel and move to `private-orders.ready.{orderId}` channel which will be use to receive message for when order is ready, ready for pickup, delivered, canceled, delayed or any order events. This need to be done bcos keeping them in `presence-orders.approved.{userId}`/FastFast means every riders in this channel will receive the message (which is why they were trying to do acceptOrderCount !> 1 (@Zucci-Daniel andd I  were struggling to understand this) )
4. Customer and Seller will be added to `private-orders.ready.{orderId}` channel too, one message event to 3 devices
5. Once the order is completed and delivered. unsubcribed them(rider,seller,customer) from `private-orders.ready.{orderId}`  and close the connection.